### PR TITLE
fixed bug when assigning access to wrong allocation object

### DIFF
--- a/src/mem_analyzer.c
+++ b/src/mem_analyzer.c
@@ -144,7 +144,7 @@ int is_sample_in_buffer(struct mem_sample *sample, struct memory_info *buffer){
   if(buffer->buffer_addr <= addr_ptr &&
      addr_ptr < buffer->buffer_addr + buffer->buffer_size) {
     /* address matches */
-    return 1;
+    // return 1; ==> address alone is not sufficient
     if(buffer->alloc_date <=sample->timestamp &&
        sample->timestamp <= buffer->free_date) {
       /* timestamp matches */


### PR DESCRIPTION
## Description
Finding the correct allocation for data accesses is currently broken. It is just considering the address range and returns the first match not considering time where the access happend. In iterative codes where data items are allocated in each iteration that often results in the same or similar address range but the allocation and deallocation times are different.

## Solution
Checking whether an access is wihtin allocation and deallocation was already there. I just commented out the return inbetween.