### PR TITLE
Fix format

### DIFF
--- a/src/mem_analyzer.c
+++ b/src/mem_analyzer.c
@@ -759,7 +759,7 @@ struct maps_file_list* insert_new_maps_file_from_line(char *line, struct maps_fi
   char pathname[1024];
 
   sscanf(line, "%"SCNuPTR"-%"SCNuPTR" %s %"SCNxPTR" %s %"SCNu64" %s\n", &addr_begin, &addr_end, permissions, &offset, device, &inode, pathname);
-  if (pathname == NULL) return current_list;
+  if (pathname[0] == '\0') return current_list;
   struct maps_file_list* current_file = current_list;
   while (current_file != NULL) {
     if (strcmp(current_file->pathname, pathname) == 0) {

--- a/src/mem_run.c
+++ b/src/mem_run.c
@@ -223,7 +223,7 @@ void* realloc(void *ptr, size_t size) {
     fprintf(stderr,"%s(%p). I can't find this pointer !\n", __FUNCTION__, ptr);
     abort();
     void* retval = librealloc(ptr, size);
-    debug_printf("%s returns --> %p\n", retval, __FUNCTION__);
+    debug_printf("%s returns --> %p\n", __FUNCTION__, retval);
     return retval;
   }
 


### PR DESCRIPTION
When compiling with Intel's compiler, there were plenty of warnings due to input/output format string.

I solved them all, referring to elf struct format to ensure the right PRI/SCN symbol is used.